### PR TITLE
Fix TUForm resizing on multiple monitors

### DIFF
--- a/Components/UCL.TUForm.pas
+++ b/Components/UCL.TUForm.pas
@@ -122,13 +122,16 @@ begin
 end;
 
 procedure TUForm.Resize;
+var
+  CurrentScreen: TMonitor;
 begin
   if WindowState = wsMaximized then
     begin
-      Self.Left := Screen.WorkAreaRect.Left;
-      Self.Top := Screen.WorkAreaRect.Top;
-      Self.Width := Screen.WorkAreaRect.Right - Screen.WorkAreaRect.Left;
-      Self.Height := Screen.WorkAreaRect.Bottom - Screen.WorkAreaRect.Top - 1;
+      CurrentScreen := Screen.MonitorFromWindow(Self.Handle);
+      Self.Left := CurrentScreen.WorkAreaRect.Left;
+      Self.Top := CurrentScreen.WorkAreaRect.Top;
+      Self.Width := CurrentScreen.WorkAreaRect.Right - CurrentScreen.WorkAreaRect.Left;
+      Self.Height := CurrentScreen.WorkAreaRect.Bottom - CurrentScreen.WorkAreaRect.Top - 1;
         //  Without -1, form will over screen size
 
       Self.Padding.SetBounds(0, 0, 0, 0);


### PR DESCRIPTION
There is a small issue on window resizing when using multiple monitors, the current TUForm resizes to the primary monitor only, whether you are on the secondary monitor or not.

This might fix that small issue.